### PR TITLE
Split socket and link implementations

### DIFF
--- a/TunnelKit/Sources/AppExtension/ConnectionStrategy.swift
+++ b/TunnelKit/Sources/AppExtension/ConnectionStrategy.swift
@@ -116,11 +116,11 @@ private extension NEProvider {
         switch endpointProtocol.socketType {
         case .udp:
             let impl = createUDPSession(to: endpoint, from: nil)
-            return NEUDPInterface(impl: impl)
+            return NEUDPSocket(impl: impl)
             
         case .tcp:
             let impl = createTCPConnection(to: endpoint, enableTLS: false, tlsParameters: nil, delegate: nil)
-            return NETCPInterface(impl: impl)
+            return NETCPSocket(impl: impl)
         }
     }
 }

--- a/TunnelKit/Sources/AppExtension/GenericSocket.swift
+++ b/TunnelKit/Sources/AppExtension/GenericSocket.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol LinkProducer {
-    func link() -> LinkInterface
+    func link(withMTU mtu: Int) -> LinkInterface
 }
 
 protocol GenericSocketDelegate: class {

--- a/TunnelKit/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/TunnelKit/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -12,7 +12,7 @@ import SwiftyBeaver
 
 private let log = SwiftyBeaver.self
 
-class NETCPInterface: NSObject, GenericSocket {
+class NETCPSocket: NSObject, GenericSocket {
     private static var linkContext = 0
     
     private let impl: NWTCPConnection
@@ -55,13 +55,13 @@ class NETCPInterface: NSObject, GenericSocket {
                 return
             }
         }
-        impl.addObserver(self, forKeyPath: #keyPath(NWTCPConnection.state), options: [.initial, .new], context: &NETCPInterface.linkContext)
-        impl.addObserver(self, forKeyPath: #keyPath(NWTCPConnection.hasBetterPath), options: .new, context: &NETCPInterface.linkContext)
+        impl.addObserver(self, forKeyPath: #keyPath(NWTCPConnection.state), options: [.initial, .new], context: &NETCPSocket.linkContext)
+        impl.addObserver(self, forKeyPath: #keyPath(NWTCPConnection.hasBetterPath), options: .new, context: &NETCPSocket.linkContext)
     }
     
     func unobserve() {
-        impl.removeObserver(self, forKeyPath: #keyPath(NWTCPConnection.state), context: &NETCPInterface.linkContext)
-        impl.removeObserver(self, forKeyPath: #keyPath(NWTCPConnection.hasBetterPath), context: &NETCPInterface.linkContext)
+        impl.removeObserver(self, forKeyPath: #keyPath(NWTCPConnection.state), context: &NETCPSocket.linkContext)
+        impl.removeObserver(self, forKeyPath: #keyPath(NWTCPConnection.hasBetterPath), context: &NETCPSocket.linkContext)
     }
     
     func shutdown() {
@@ -73,17 +73,17 @@ class NETCPInterface: NSObject, GenericSocket {
         guard impl.hasBetterPath else {
             return nil
         }
-        return NETCPInterface(impl: NWTCPConnection(upgradeFor: impl))
+        return NETCPSocket(impl: NWTCPConnection(upgradeFor: impl))
     }
     
     func link(withMTU mtu: Int) -> LinkInterface {
-        return NETCPLinkInterface(impl: impl)
+        return NETCPLink(impl: impl)
     }
     
     // MARK: Connection KVO (any queue)
     
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        guard (context == &NETCPInterface.linkContext) else {
+        guard (context == &NETCPSocket.linkContext) else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
             return
         }
@@ -147,7 +147,7 @@ class NETCPInterface: NSObject, GenericSocket {
     }
 }
 
-class NETCPLinkInterface: LinkInterface {
+class NETCPLink: LinkInterface {
     private let impl: NWTCPConnection
     
     private let maxPacketSize: Int
@@ -219,7 +219,7 @@ class NETCPLinkInterface: LinkInterface {
     }
 }
 
-extension NETCPInterface {
+extension NETCPSocket {
     override var description: String {
         guard let hostEndpoint = impl.endpoint as? NWHostEndpoint else {
             return impl.endpoint.description

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider+Configuration.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider+Configuration.swift
@@ -125,8 +125,8 @@ extension TunnelKitProvider {
         /// The optional CA certificate to validate server against. Set to `nil` to disable CA validation (default).
         public var ca: Certificate?
         
-        /// The MTU of the tunnel.
-        public var mtu: NSNumber
+        /// The MTU of the link.
+        public var mtu: Int
         
         /// Enables LZO framing (deprecated).
 //        @available(*, deprecated)
@@ -214,7 +214,7 @@ extension TunnelKitProvider {
             self.cipher = cipher
             self.digest = digest
             self.ca = ca
-            mtu = providerConfiguration[S.mtu] as? NSNumber ?? 1500
+            mtu = providerConfiguration[S.mtu] as? Int ?? 1250
             LZOFraming = providerConfiguration[S.LZOFraming] as? Bool ?? false
             renegotiatesAfterSeconds = providerConfiguration[S.renegotiatesAfter] as? Int
 
@@ -310,7 +310,7 @@ extension TunnelKitProvider {
         public let ca: Certificate?
         
         /// - Seealso: `TunnelKitProvider.ConfigurationBuilder.mtu`
-        public let mtu: NSNumber
+        public let mtu: Int
         
         /// - Seealso: `TunnelKitProvider.ConfigurationBuilder.LZOFraming`
         public let LZOFraming: Bool

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -335,10 +335,10 @@ extension TunnelKitProvider: GenericSocketDelegate {
             return
         }
         if proxy.canRebindLink() {
-            proxy.rebindLink(socket.link())
+            proxy.rebindLink(socket.link(withMTU: 1000))
             reasserting = false
         } else {
-            proxy.setLink(socket.link())
+            proxy.setLink(socket.link(withMTU: 1000))
         }
     }
     

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -335,10 +335,10 @@ extension TunnelKitProvider: GenericSocketDelegate {
             return
         }
         if proxy.canRebindLink() {
-            proxy.rebindLink(socket.link(withMTU: 1000))
+            proxy.rebindLink(socket.link(withMTU: cfg.mtu))
             reasserting = false
         } else {
-            proxy.setLink(socket.link(withMTU: 1000))
+            proxy.setLink(socket.link(withMTU: cfg.mtu))
         }
     }
     
@@ -446,7 +446,6 @@ extension TunnelKitProvider: SessionProxyDelegate {
         let newSettings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: tunnel)
         newSettings.ipv4Settings = ipv4Settings
         newSettings.dnsSettings = dnsSettings
-        newSettings.mtu = cfg.mtu
         
         setTunnelNetworkSettings(newSettings, completionHandler: completionHandler)
     }

--- a/TunnelKitTests/AppExtensionTests.swift
+++ b/TunnelKitTests/AppExtensionTests.swift
@@ -59,7 +59,7 @@ class AppExtensionTests: XCTestCase {
         XCTAssertEqual(proto?.providerConfiguration?[K.cipherAlgorithm] as? String, cfg.cipher.rawValue)
         XCTAssertEqual(proto?.providerConfiguration?[K.digestAlgorithm] as? String, cfg.digest.rawValue)
         XCTAssertEqual(proto?.providerConfiguration?[K.ca] as? String, cfg.ca?.pem)
-        XCTAssertEqual(proto?.providerConfiguration?[K.mtu] as? NSNumber, cfg.mtu)
+        XCTAssertEqual(proto?.providerConfiguration?[K.mtu] as? Int, cfg.mtu)
         XCTAssertEqual(proto?.providerConfiguration?[K.renegotiatesAfter] as? Int, cfg.renegotiatesAfterSeconds)
         XCTAssertEqual(proto?.providerConfiguration?[K.debug] as? Bool, cfg.shouldDebug)
         XCTAssertEqual(proto?.providerConfiguration?[K.debugLogKey] as? String, cfg.debugLogKey)


### PR DESCRIPTION
Separate UDP and TCP implementations of `GenericSocket` (AppExtension) and `LinkInterface` (Core).

Helps focusing on specific business:

- Socket: connect/bind to remote address, observe state, shut down etc.
- Link: transfer data.

Changes in MTU handling (`TunnelKitProvider.Configuration.mtu`):

- The MTU setting is now used for link.
- Default MTU for UDP is 1250 (was 1000).
- Tunnel MTU is left to default and not customizable.