### PR TITLE
Add initial NCP support

### DIFF
--- a/TunnelKit/Sources/Core/CoreConfiguration.swift
+++ b/TunnelKit/Sources/Core/CoreConfiguration.swift
@@ -61,6 +61,7 @@ struct CoreConfiguration {
     static let peerInfo = [
         "IV_VER=2.3.99",
         "IV_PROTO=2",
+        "IV_NCP=2",
         ""
     ].joined(separator: "\n")
     

--- a/TunnelKit/Sources/Core/CoreConfiguration.swift
+++ b/TunnelKit/Sources/Core/CoreConfiguration.swift
@@ -59,7 +59,7 @@ struct CoreConfiguration {
     // MARK: Authentication
     
     static let peerInfo = [
-        "IV_VER=2.3.99",
+        "IV_VER=2.4",
         "IV_PROTO=2",
         "IV_NCP=2",
         ""

--- a/TunnelKit/Sources/Core/DataPath.h
+++ b/TunnelKit/Sources/Core/DataPath.h
@@ -47,11 +47,10 @@
 
 - (nonnull instancetype)initWithEncrypter:(nonnull id<DataPathEncrypter>)encrypter
                                 decrypter:(nonnull id<DataPathDecrypter>)decrypter
+                                   peerId:(uint32_t)peerId // 24-bit, discard most significant byte
+                       compressionFraming:(CompressionFramingNative)compressionFraming
                                maxPackets:(NSInteger)maxPackets
                      usesReplayProtection:(BOOL)usesReplayProtection;
-
-- (void)setPeerId:(uint32_t)peerId; // 24-bit, discard most significant byte
-- (void)setCompressionFraming:(CompressionFramingNative)compressionFraming;
 
 - (NSArray<NSData *> *)encryptPackets:(nonnull NSArray<NSData *> *)packets key:(uint8_t)key error:(NSError **)error;
 - (NSArray<NSData *> *)decryptPackets:(nonnull NSArray<NSData *> *)packets keepAlive:(nullable bool *)keepAlive error:(NSError **)error;

--- a/TunnelKit/Sources/Core/DataPath.m
+++ b/TunnelKit/Sources/Core/DataPath.m
@@ -80,7 +80,7 @@
     return (uint8_t *)addr;
 }
 
-- (instancetype)initWithEncrypter:(id<DataPathEncrypter>)encrypter decrypter:(id<DataPathDecrypter>)decrypter maxPackets:(NSInteger)maxPackets usesReplayProtection:(BOOL)usesReplayProtection
+- (instancetype)initWithEncrypter:(id<DataPathEncrypter>)encrypter decrypter:(id<DataPathDecrypter>)decrypter peerId:(uint32_t)peerId compressionFraming:(CompressionFramingNative)compressionFraming maxPackets:(NSInteger)maxPackets usesReplayProtection:(BOOL)usesReplayProtection
 {
     NSParameterAssert(encrypter);
     NSParameterAssert(decrypter);
@@ -103,7 +103,9 @@
             self.inReplay = [[ReplayProtector alloc] init];
         }
 
-        self.compressionFraming = CompressionFramingNativeDisabled;
+        [self.encrypter setPeerId:peerId];
+        [self.decrypter setPeerId:peerId];
+        [self setCompressionFraming:compressionFraming];
     }
     return self;
 }
@@ -148,15 +150,6 @@
 - (uint8_t *)decBufferAligned
 {
     return [[self class] alignedPointer:self.decBuffer];
-}
-
-- (void)setPeerId:(uint32_t)peerId
-{
-    NSAssert(self.encrypter, @"Setting peer-id to nil encrypter");
-    NSAssert(self.decrypter, @"Setting peer-id to nil decrypter");
-
-    [self.encrypter setPeerId:peerId];
-    [self.decrypter setPeerId:peerId];
 }
 
 - (void)setCompressionFraming:(CompressionFramingNative)compressionFraming

--- a/TunnelKit/Sources/Core/SessionProxy+PushReply.swift
+++ b/TunnelKit/Sources/Core/SessionProxy+PushReply.swift
@@ -147,6 +147,9 @@ public protocol SessionReply {
     /// The DNS servers set up for this session.
     var dnsServers: [String] { get }
     
+    /// The optional authentication token.
+    var authToken: String? { get }
+    
     /// The optional 24-bit peer-id.
     var peerId: UInt32? { get }
 

--- a/TunnelKit/Sources/Core/SessionProxy+SessionKey.swift
+++ b/TunnelKit/Sources/Core/SessionProxy+SessionKey.swift
@@ -74,8 +74,6 @@ extension SessionProxy {
 
         private var isTLSConnected: Bool
         
-        private var canHandlePackets: Bool
-        
         init(id: UInt8) {
             self.id = id
 
@@ -83,7 +81,6 @@ extension SessionProxy {
             state = .invalid
             softReset = false
             isTLSConnected = false
-            canHandlePackets = false
         }
 
         // Ruby: Key.hard_reset_timeout
@@ -109,19 +106,9 @@ extension SessionProxy {
             return isTLSConnected
         }
         
-        func startHandlingPackets(withPeerId peerId: UInt32? = nil, compressionFraming: CompressionFraming = .disabled) {
-            dataPath?.setPeerId(peerId ?? PacketPeerIdDisabled)
-            dataPath?.setCompressionFraming(compressionFraming.native)
-            canHandlePackets = true
-        }
-        
         func encrypt(packets: [Data]) throws -> [Data]? {
             guard let dataPath = dataPath else {
                 log.warning("Data: Set dataPath first")
-                return nil
-            }
-            guard canHandlePackets else {
-                log.warning("Data: Invoke startHandlingPackets() before encrypting")
                 return nil
             }
             return try dataPath.encryptPackets(packets, key: id)
@@ -130,10 +117,6 @@ extension SessionProxy {
         func decrypt(packets: [Data]) throws -> [Data]? {
             guard let dataPath = dataPath else {
                 log.warning("Data: Set dataPath first")
-                return nil
-            }
-            guard canHandlePackets else {
-                log.warning("Data: Invoke startHandlingPackets() before decrypting")
                 return nil
             }
             var keepAlive = false

--- a/TunnelKit/Sources/Core/SessionProxy.swift
+++ b/TunnelKit/Sources/Core/SessionProxy.swift
@@ -848,8 +848,6 @@ public class SessionProxy {
                 return
             }
             
-            setupKeys()
-
             negotiationKey.controlState = .preIfConfig
             nextPushRequestDate = Date().addingTimeInterval(negotiationKey.softReset ? CoreConfiguration.softResetDelay : CoreConfiguration.retransmissionLimit)
             pushRequest()
@@ -890,6 +888,8 @@ public class SessionProxy {
             deferStop(.shutdown, e)
             return
         }
+        
+        setupEncryption()
         
         authenticator = nil
         negotiationKey.startHandlingPackets(
@@ -1007,7 +1007,7 @@ public class SessionProxy {
     }
     
     // Ruby: setup_keys
-    private func setupKeys() {
+    private func setupEncryption() {
         guard let auth = authenticator else {
             fatalError("Setting up keys without having authenticated")
         }

--- a/TunnelKit/Sources/Core/SessionProxy.swift
+++ b/TunnelKit/Sources/Core/SessionProxy.swift
@@ -702,7 +702,6 @@ public class SessionProxy {
         
         if negotiationKey.softReset {
             authenticator = nil
-            negotiationKey.startHandlingPackets(withPeerId: peerId)
             negotiationKey.controlState = .connected
             connectedDate = Date()
             transitionKeys()
@@ -890,12 +889,7 @@ public class SessionProxy {
         }
         
         setupEncryption()
-        
         authenticator = nil
-        negotiationKey.startHandlingPackets(
-            withPeerId: peerId,
-            compressionFraming: configuration.compressionFraming
-        )
         negotiationKey.controlState = .connected
         connectedDate = Date()
         transitionKeys()
@@ -1051,6 +1045,8 @@ public class SessionProxy {
         negotiationKey.dataPath = DataPath(
             encrypter: bridge.encrypter(),
             decrypter: bridge.decrypter(),
+            peerId: peerId ?? PacketPeerIdDisabled,
+            compressionFraming: configuration.compressionFraming.native,
             maxPackets: link?.packetBufferSize ?? 200,
             usesReplayProtection: CoreConfiguration.usesReplayProtection
         )

--- a/TunnelKit/Sources/Core/SessionProxy.swift
+++ b/TunnelKit/Sources/Core/SessionProxy.swift
@@ -701,10 +701,7 @@ public class SessionProxy {
         enqueueControlPackets(code: .controlV1, key: negotiationKey.id, payload: cipherTextOut)
         
         if negotiationKey.softReset {
-            authenticator = nil
-            negotiationKey.controlState = .connected
-            connectedDate = Date()
-            transitionKeys()
+            completeConnection()
         }
         nextPushRequestDate = Date().addingTimeInterval(CoreConfiguration.retransmissionLimit)
     }
@@ -722,6 +719,14 @@ public class SessionProxy {
             log.debug("Renegotiating after \(elapsed) seconds")
             softReset()
         }
+    }
+    
+    private func completeConnection() {
+        setupEncryption()
+        authenticator = nil
+        negotiationKey.controlState = .connected
+        connectedDate = Date()
+        transitionKeys()
     }
     
     // MARK: Control
@@ -888,11 +893,7 @@ public class SessionProxy {
             return
         }
         
-        setupEncryption()
-        authenticator = nil
-        negotiationKey.controlState = .connected
-        connectedDate = Date()
-        transitionKeys()
+        completeConnection()
 
         guard let remoteAddress = link?.remoteAddress else {
             fatalError("Could not resolve link remote address")

--- a/TunnelKitTests/DataPathEncryptionTests.swift
+++ b/TunnelKitTests/DataPathEncryptionTests.swift
@@ -87,8 +87,14 @@ class DataPathEncryptionTests: XCTestCase {
     }
     
     func privateTestDataPathHigh(peerId: UInt32?) {
-        let path = DataPath(encrypter: enc, decrypter: dec, maxPackets: 1000, usesReplayProtection: false)
-        path.setCompressionFraming(.disabled)
+        let path = DataPath(
+            encrypter: enc,
+            decrypter: dec,
+            peerId: peerId ?? PacketPeerIdDisabled,
+            compressionFraming: .disabled,
+            maxPackets: 1000,
+            usesReplayProtection: false
+        )
 
         if let peerId = peerId {
             enc.setPeerId(peerId)

--- a/TunnelKitTests/DataPathPerformanceTests.swift
+++ b/TunnelKitTests/DataPathPerformanceTests.swift
@@ -54,7 +54,14 @@ class DataPathPerformanceTests: XCTestCase {
         encrypter = crypto.encrypter()
         decrypter = crypto.decrypter()
         
-        dataPath = DataPath(encrypter: encrypter, decrypter: decrypter, maxPackets: 200, usesReplayProtection: false)
+        dataPath = DataPath(
+            encrypter: encrypter,
+            decrypter: decrypter,
+            peerId: PacketPeerIdDisabled,
+            compressionFraming: .disabled,
+            maxPackets: 200,
+            usesReplayProtection: false
+        )
     }
 
     override func tearDown() {

--- a/TunnelKitTests/PushTests.swift
+++ b/TunnelKitTests/PushTests.swift
@@ -91,4 +91,12 @@ class PushTests: XCTestCase {
         XCTAssertEqual(reply.ipv6?.defaultGateway, "fe80::601:30ff:feb7:dc02")
         XCTAssertEqual(reply.dnsServers, ["2001:4860:4860::8888", "2001:4860:4860::8844"])
     }
+    
+    func testNCP() {
+        let msg = "PUSH_REPLY,dhcp-option DNS 8.8.8.8,dhcp-option DNS 4.4.4.4,comp-lzo no,route 10.8.0.1,topology net30,ping 10,ping-restart 120,ifconfig 10.8.0.6 10.8.0.5,peer-id 0,cipher AES-256-CBC"
+        let reply = try! SessionProxy.PushReply(message: msg)!
+        reply.debug()
+
+        XCTAssertEqual(reply.cipher, .aes256cbc)
+    }
 }


### PR DESCRIPTION
Parse cipher from PUSH_REPLY when present. Reflects default OpenVPN 2.4 behavior, namely NCP (Negotiable Crypto Parameters).

Also fixes a bug in compression framing not retained after SOFT_RESET.