### PR TITLE
Decouple provider configuration

### DIFF
--- a/Demo/BasicTunnel-iOS/ViewController.swift
+++ b/Demo/BasicTunnel-iOS/ViewController.swift
@@ -30,7 +30,7 @@ extension ViewController {
             password: password
         )
         
-        var builder = TunnelKitProvider.ConfigurationBuilder(appGroup: ViewController.appGroup)
+        var builder = TunnelKitProvider.ConfigurationBuilder()
         let socketType: TunnelKitProvider.SocketType = switchTCP.isOn ? .tcp : .udp
         builder.endpointProtocols = [TunnelKitProvider.EndpointProtocol(socketType, port)]
         builder.cipher = .aes128cbc
@@ -44,6 +44,7 @@ extension ViewController {
         let configuration = builder.build()
         return try! configuration.generatedTunnelProtocol(
             withBundleIdentifier: ViewController.bundleIdentifier,
+            appGroup: ViewController.appGroup,
             endpoint: endpoint
         )
     }

--- a/Demo/BasicTunnel-macOS/ViewController.swift
+++ b/Demo/BasicTunnel-macOS/ViewController.swift
@@ -30,7 +30,7 @@ extension ViewController {
             password: password
         )
 
-        var builder = TunnelKitProvider.ConfigurationBuilder(appGroup: ViewController.appGroup)
+        var builder = TunnelKitProvider.ConfigurationBuilder()
 //        let socketType: TunnelKitProvider.SocketType = isTCP ? .tcp : .udp
         let socketType: TunnelKitProvider.SocketType = .udp
         builder.endpointProtocols = [TunnelKitProvider.EndpointProtocol(socketType, port)]
@@ -45,6 +45,7 @@ extension ViewController {
         let configuration = builder.build()
         return try! configuration.generatedTunnelProtocol(
             withBundleIdentifier: ViewController.bundleIdentifier,
+            appGroup: ViewController.appGroup,
             endpoint: endpoint
         )
     }

--- a/TunnelKit.xcodeproj/project.pbxproj
+++ b/TunnelKit.xcodeproj/project.pbxproj
@@ -64,8 +64,6 @@
 		0ECE352A212EB88E0040F253 /* CryptoContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECE3527212EB7770040F253 /* CryptoContainer.swift */; };
 		0ED9C8642138139000621BA3 /* SessionProxy+CompressionFraming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED9C8632138139000621BA3 /* SessionProxy+CompressionFraming.swift */; };
 		0ED9C8652138139000621BA3 /* SessionProxy+CompressionFraming.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED9C8632138139000621BA3 /* SessionProxy+CompressionFraming.swift */; };
-		0EE7A79520F61EDC00B42E6A /* PacketMacros.h in Sources */ = {isa = PBXBuildFile; fileRef = 0EE7A79420F61EDC00B42E6A /* PacketMacros.h */; };
-		0EE7A79620F61EDC00B42E6A /* PacketMacros.h in Sources */ = {isa = PBXBuildFile; fileRef = 0EE7A79420F61EDC00B42E6A /* PacketMacros.h */; };
 		0EE7A79820F6296F00B42E6A /* PacketMacros.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EE7A79720F6296F00B42E6A /* PacketMacros.m */; };
 		0EE7A79920F6296F00B42E6A /* PacketMacros.m in Sources */ = {isa = PBXBuildFile; fileRef = 0EE7A79720F6296F00B42E6A /* PacketMacros.m */; };
 		0EE7A7A120F664AC00B42E6A /* DataPathEncryptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE7A7A020F664AB00B42E6A /* DataPathEncryptionTests.swift */; };
@@ -79,6 +77,9 @@
 		0EEC49E820B5F7F6008FEB91 /* ReplayProtector.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EFEB4392006D3C800F81029 /* ReplayProtector.h */; };
 		0EEC49E920B5F7F6008FEB91 /* TLSBox.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EFEB4442006D3C800F81029 /* TLSBox.h */; };
 		0EEC49EA20B5F7F6008FEB91 /* ZeroingData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EFEB4412006D3C800F81029 /* ZeroingData.h */; };
+		0EF5CF262141E142004FF1BD /* PacketMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE7A79420F61EDC00B42E6A /* PacketMacros.h */; };
+		0EF5CF272141E15B004FF1BD /* PacketMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EE7A79420F61EDC00B42E6A /* PacketMacros.h */; };
+		0EF5CF282141E183004FF1BD /* CompressionFramingNative.h in Headers */ = {isa = PBXBuildFile; fileRef = 0E245D6B2137F73600B012A2 /* CompressionFramingNative.h */; };
 		0EFEB4552006D3C800F81029 /* SessionProxy+EncryptionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFEB42A2006D3C800F81029 /* SessionProxy+EncryptionBridge.swift */; };
 		0EFEB4562006D3C800F81029 /* SessionProxy+SessionKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFEB42B2006D3C800F81029 /* SessionProxy+SessionKey.swift */; };
 		0EFEB4582006D3C800F81029 /* MSS.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EFEB42D2006D3C800F81029 /* MSS.h */; };
@@ -172,7 +173,7 @@
 
 /* Begin PBXFileReference section */
 		0E07595C20EF6D1400F38FD8 /* CryptoCBC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CryptoCBC.m; sourceTree = "<group>"; };
-		0E07596120EF733F00F38FD8 /* CryptoMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CryptoMacros.h; sourceTree = "<group>"; };
+		0E07596120EF733F00F38FD8 /* CryptoMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CryptoMacros.h; sourceTree = "<group>"; };
 		0E07596A20EF79AB00F38FD8 /* Encryption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Encryption.h; sourceTree = "<group>"; };
 		0E07596D20EF79B400F38FD8 /* CryptoCBC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CryptoCBC.h; sourceTree = "<group>"; };
 		0E07597C20F0060E00F38FD8 /* CryptoAEAD.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CryptoAEAD.h; sourceTree = "<group>"; };
@@ -216,7 +217,7 @@
 		0EC1BBA720D7D803007C4C7B /* ConnectionStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionStrategy.swift; sourceTree = "<group>"; };
 		0ECE3527212EB7770040F253 /* CryptoContainer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CryptoContainer.swift; sourceTree = "<group>"; };
 		0ED9C8632138139000621BA3 /* SessionProxy+CompressionFraming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionProxy+CompressionFraming.swift"; sourceTree = "<group>"; };
-		0EE7A79420F61EDC00B42E6A /* PacketMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PacketMacros.h; sourceTree = "<group>"; };
+		0EE7A79420F61EDC00B42E6A /* PacketMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PacketMacros.h; sourceTree = "<group>"; };
 		0EE7A79720F6296F00B42E6A /* PacketMacros.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PacketMacros.m; sourceTree = "<group>"; };
 		0EE7A79D20F6488400B42E6A /* DataPathEncryption.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DataPathEncryption.h; sourceTree = "<group>"; };
 		0EE7A7A020F664AB00B42E6A /* DataPathEncryptionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataPathEncryptionTests.swift; sourceTree = "<group>"; };
@@ -509,6 +510,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0EF5CF262141E142004FF1BD /* PacketMacros.h in Headers */,
 				0EFEB4642006D3C800F81029 /* ReplayProtector.h in Headers */,
 				0EFEB4612006D3C800F81029 /* Errors.h in Headers */,
 				0E07596E20EF79B400F38FD8 /* CryptoCBC.h in Headers */,
@@ -529,6 +531,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0EF5CF272141E15B004FF1BD /* PacketMacros.h in Headers */,
 				0EEC49E620B5F7F6008FEB91 /* MSS.h in Headers */,
 				0EEC49E520B5F7F6008FEB91 /* Errors.h in Headers */,
 				0E07596F20EF79B400F38FD8 /* CryptoCBC.h in Headers */,
@@ -537,6 +540,7 @@
 				0E07596C20EF79AB00F38FD8 /* Encryption.h in Headers */,
 				0EEC49E120B5F7EA008FEB91 /* Allocation.h in Headers */,
 				0EEC49E320B5F7F6008FEB91 /* DataPath.h in Headers */,
+				0EF5CF282141E183004FF1BD /* CompressionFramingNative.h in Headers */,
 				0EEC49E820B5F7F6008FEB91 /* ReplayProtector.h in Headers */,
 				0EEC49E920B5F7F6008FEB91 /* TLSBox.h in Headers */,
 				0E07597F20F0060E00F38FD8 /* CryptoAEAD.h in Headers */,
@@ -838,7 +842,6 @@
 				0EFEB4AE2007625E00F81029 /* Keychain.swift in Sources */,
 				0EBBF3002085196000E36B40 /* NWTCPConnectionState+Description.swift in Sources */,
 				0EFEB4622006D3C800F81029 /* SecureRandom.swift in Sources */,
-				0EE7A79520F61EDC00B42E6A /* PacketMacros.h in Sources */,
 				0EFEB45D2006D3C800F81029 /* CryptoBox.m in Sources */,
 				0EBBF2FA2085061600E36B40 /* NETCPInterface.swift in Sources */,
 				0E0C2125212ED29D008AB282 /* SessionError.swift in Sources */,
@@ -891,7 +894,6 @@
 				0EFEB4992006D7F300F81029 /* SessionProxy.swift in Sources */,
 				0EBBF3012085196000E36B40 /* NWTCPConnectionState+Description.swift in Sources */,
 				0EFEB4962006D7F300F81029 /* ProtocolMacros.swift in Sources */,
-				0EE7A79620F61EDC00B42E6A /* PacketMacros.h in Sources */,
 				0EFEB48A2006D7C400F81029 /* TunnelKitProvider.swift in Sources */,
 				0E0C2126212ED29D008AB282 /* SessionError.swift in Sources */,
 				0EBBF2FB2085061600E36B40 /* NETCPInterface.swift in Sources */,

--- a/TunnelKitTests/AppExtensionTests.swift
+++ b/TunnelKitTests/AppExtensionTests.swift
@@ -63,7 +63,7 @@ class AppExtensionTests: XCTestCase {
             password: "bar"
         )
 
-        builder = TunnelKitProvider.ConfigurationBuilder(appGroup: appGroup)
+        builder = TunnelKitProvider.ConfigurationBuilder()
         XCTAssertNotNil(builder)
 
         builder.cipher = .aes128cbc
@@ -71,7 +71,7 @@ class AppExtensionTests: XCTestCase {
         builder.ca = CryptoContainer(pem: "abcdef")
         cfg = builder.build()
 
-        let proto = try? cfg.generatedTunnelProtocol(withBundleIdentifier: identifier, endpoint: endpoint)
+        let proto = try? cfg.generatedTunnelProtocol(withBundleIdentifier: identifier, appGroup: appGroup, endpoint: endpoint)
         XCTAssertNotNil(proto)
         
         XCTAssertEqual(proto?.providerBundleIdentifier, identifier)
@@ -84,7 +84,7 @@ class AppExtensionTests: XCTestCase {
         }
         
         let K = TunnelKitProvider.Configuration.Keys.self
-        XCTAssertEqual(proto?.providerConfiguration?[K.appGroup] as? String, cfg.appGroup)
+        XCTAssertEqual(proto?.providerConfiguration?[K.appGroup] as? String, appGroup)
         XCTAssertEqual(proto?.providerConfiguration?[K.cipherAlgorithm] as? String, cfg.cipher.rawValue)
         XCTAssertEqual(proto?.providerConfiguration?[K.digestAlgorithm] as? String, cfg.digest.rawValue)
         XCTAssertEqual(proto?.providerConfiguration?[K.ca] as? String, cfg.ca?.pem)


### PR DESCRIPTION
Only retain VPN-specific parameters in `TunnelKitProvider.Configuration`. Move `appGroup` out.

This will help parsing .ovpn configuration files later.