### PR TITLE
Interpret 0 reneg seconds as never

### DIFF
--- a/TunnelKit/Sources/Core/SessionProxy.swift
+++ b/TunnelKit/Sources/Core/SessionProxy.swift
@@ -704,7 +704,7 @@ public class SessionProxy {
     }
     
     private func maybeRenegotiate() {
-        guard let renegotiatesAfter = configuration.renegotiatesAfter else {
+        guard let renegotiatesAfter = configuration.renegotiatesAfter, renegotiatesAfter > 0 else {
             return
         }
         guard (negotiationKeyIdx == currentKeyIdx) else {


### PR DESCRIPTION
Continuous soft resets would happen otherwise with a very low value.