### PR TITLE
Do not recover data on known errors

### DIFF
--- a/TunnelKit/Sources/AppExtension/GenericSocket.swift
+++ b/TunnelKit/Sources/AppExtension/GenericSocket.swift
@@ -44,7 +44,7 @@ protocol LinkProducer {
 protocol GenericSocketDelegate: class {
     func socketDidTimeout(_ socket: GenericSocket)
 
-    func socketShouldChangeProtocol(_ socket: GenericSocket)
+    func socketShouldChangeProtocol(_ socket: GenericSocket) -> Bool
     
     func socketDidBecomeActive(_ socket: GenericSocket)
 

--- a/TunnelKit/Sources/AppExtension/Transport/NETCPInterface.swift
+++ b/TunnelKit/Sources/AppExtension/Transport/NETCPInterface.swift
@@ -79,7 +79,7 @@ class NETCPSocket: NSObject, GenericSocket {
                 return
             }
             guard _self.isActive else {
-                _self.delegate?.socketShouldChangeProtocol(_self)
+                _ = _self.delegate?.socketShouldChangeProtocol(_self)
                 _self.delegate?.socketDidTimeout(_self)
                 return
             }

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -420,18 +420,27 @@ extension TunnelKitProvider: GenericSocketDelegate {
             log.debug("Link failures so far: \(linkFailures) (max = \(maxLinkFailures))")
         }
         
+        // neg timeout?
+        let didTimeoutNegotiation = (proxy.stopError as? SessionError == .negotiationTimeout)
+        
         // only try upgrade on network errors
         var upgradedSocket: GenericSocket? = nil
         if shutdownError as? SessionError == nil {
             upgradedSocket = socket.upgraded()
         }
-        
+
+        // clean up
+        finishTunnelDisconnection(error: shutdownError)
+
         // treat negotiation timeout as socket timeout, UDP is connection-less
-        if proxy.stopError as? SessionError == SessionError.negotiationTimeout {
-            socketShouldChangeProtocol(socket)
+        if didTimeoutNegotiation {
+            guard socketShouldChangeProtocol(socket) else {
+                // disposeTunnel
+                return
+            }
         }
 
-        finishTunnelDisconnection(error: shutdownError)
+        // reconnect?
         if reasserting {
             guard (linkFailures < maxLinkFailures) else {
                 log.debug("Too many link failures (\(linkFailures)), tunnel will die now")
@@ -445,6 +454,8 @@ extension TunnelKitProvider: GenericSocketDelegate {
             }
             return
         }
+
+        // shut down
         disposeTunnel(error: shutdownError)
     }
     

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -386,11 +386,12 @@ extension TunnelKitProvider: GenericSocketDelegate {
         socket.shutdown()
     }
     
-    func socketShouldChangeProtocol(_ socket: GenericSocket) {
+    func socketShouldChangeProtocol(_ socket: GenericSocket) -> Bool {
         guard strategy.tryNextProtocol() else {
             disposeTunnel(error: ProviderError.exhaustedProtocols)
-            return
+            return false
         }
+        return true
     }
     
     func socketDidBecomeActive(_ socket: GenericSocket) {

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -410,9 +410,6 @@ extension TunnelKitProvider: GenericSocketDelegate {
             return
         }
         
-        // upgrade available?
-        let upgradedSocket = socket.upgraded()
-        
         var shutdownError: Error?
         if !failure {
             shutdownError = proxy.stopError
@@ -420,6 +417,12 @@ extension TunnelKitProvider: GenericSocketDelegate {
             shutdownError = proxy.stopError ?? ProviderError.linkError
             linkFailures += 1
             log.debug("Link failures so far: \(linkFailures) (max = \(maxLinkFailures))")
+        }
+        
+        // only try upgrade on network errors
+        var upgradedSocket: GenericSocket? = nil
+        if shutdownError as? SessionError == nil {
+            upgradedSocket = socket.upgraded()
         }
         
         // treat negotiation timeout as socket timeout, UDP is connection-less

--- a/TunnelKit/Sources/Core/SessionProxy.swift
+++ b/TunnelKit/Sources/Core/SessionProxy.swift
@@ -42,6 +42,11 @@ import __TunnelKitNative
 private let log = SwiftyBeaver.self
 
 private extension Error {
+    func isTunnelError() -> Bool {
+        let te = self as NSError
+        return te.domain == TunnelKitErrorDomain
+    }
+    
     func isDataPathOverflow() -> Bool {
         let te = self as NSError
         return te.domain == TunnelKitErrorDomain && te.code == TunnelKitErrorCode.dataPathOverflow.rawValue
@@ -1080,7 +1085,7 @@ public class SessionProxy {
 
             tunnel?.writePackets(decryptedPackets, completionHandler: nil)
         } catch let e {
-            guard !e.isDataPathOverflow() else {
+            guard !e.isTunnelError() else {
                 deferStop(.shutdown, e)
                 return
             }
@@ -1115,7 +1120,7 @@ public class SessionProxy {
 //                log.verbose("Data: \(encryptedPackets.count) packets successfully written to LINK")
             }
         } catch let e {
-            guard !e.isDataPathOverflow() else {
+            guard !e.isTunnelError() else {
                 deferStop(.shutdown, e)
                 return
             }


### PR DESCRIPTION
Was reconnecting after ack-ing e.g. algorithm mismatch errors. Shut down instead.