### PR TITLE
Handle server-initiated reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - CA file was not closed after MD5 calculation when using PIA patches.
 - Mitigated an issue with MTU in TCP mode during negotiation. [#39](https://github.com/keeshux/tunnelkit/issues/39)
+- Handle server-initiated renegotiation. [#41](https://github.com/keeshux/tunnelkit/pull/41)
 
 ## 1.2.0 (2018-10-20)
 

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -652,7 +652,7 @@ extension TunnelKitProvider {
             }
         } else if let se = error as? SessionError {
             switch se {
-            case .negotiationTimeout, .pingTimeout:
+            case .negotiationTimeout, .pingTimeout, .staleSession:
                 return .timeout
                 
             case .badCredentials:

--- a/TunnelKit/Sources/Core/SessionError.swift
+++ b/TunnelKit/Sources/Core/SessionError.swift
@@ -67,6 +67,9 @@ public enum SessionError: String, Error {
     
     /// The server couldn't ping back before timeout.
     case pingTimeout
+    
+    /// The session reached a stale state and can't be recovered.
+    case staleSession
 }
 
 extension Error {


### PR DESCRIPTION
Renegotiation (aka `SOFT_RESET`) is not currently handled when requested by the server. After 60s, the server would mark the session as a "lame duck" and send a `HARD_RESET`. The connection may then stop working.

Fixes for when the server sends a spontaneous:

- `SOFT_RESET`: initiate a renegotiation.
- `HARD_RESET`: shut down the session/socket.