### PR TITLE
Endianness-agnostic IPv4/UInt32 conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- IPv4/UInt32 conversions are not endianness-agnostic. [#46](https://github.com/keeshux/tunnelkit/pull/46)
+
 ## 1.3.0 (2018-10-28)
 
 ### Changed


### PR DESCRIPTION
I don't seem to get endianness right apparently... but this should fix the issue once and for all. `DNSResolver` now takes input and returns output in host endianness, and uses the standard BSD API `inet_pton/inet_ntop`.

Endianness is crucial because iOS devices are big endian whereas macOS devices are little endian, and this library is meant to be compatible with both.