### PR TITLE
Override DNS servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Override DNS servers client side. [#56](https://github.com/keeshux/tunnelkit/pull/56)
+
 ### Fixed
 
 - Compiling errors in demo target.

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider+Configuration.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider+Configuration.swift
@@ -64,7 +64,8 @@ extension TunnelKitProvider {
                 tlsWrap: nil,
                 keepAliveInterval: nil,
                 renegotiatesAfter: nil,
-                usesPIAPatches: nil
+                usesPIAPatches: nil,
+                dnsServers: nil
             ),
             shouldDebug: false,
             debugLogKey: nil,

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -499,7 +499,7 @@ extension TunnelKitProvider: SessionProxyDelegate {
             ipv6Settings?.excludedRoutes = []
         }
         
-        let dnsSettings = NEDNSSettings(servers: reply.dnsServers)
+        let dnsSettings = NEDNSSettings(servers: cfg.sessionConfiguration.dnsServers ?? reply.dnsServers)
         
         let newSettings = NEPacketTunnelNetworkSettings(tunnelRemoteAddress: remoteAddress)
         newSettings.ipv4Settings = ipv4Settings

--- a/TunnelKit/Sources/Core/SessionProxy+Configuration.swift
+++ b/TunnelKit/Sources/Core/SessionProxy+Configuration.swift
@@ -165,6 +165,9 @@ extension SessionProxy {
         /// Server is patched for the PIA VPN provider.
         public var usesPIAPatches: Bool?
 
+        /// Optionally override the server DNS entries.
+        public var dnsServers: [String]?
+        
         /// :nodoc:
         public init(ca: CryptoContainer) {
             cipher = .aes128cbc
@@ -177,6 +180,7 @@ extension SessionProxy {
             keepAliveInterval = nil
             renegotiatesAfter = nil
             usesPIAPatches = false
+            dnsServers = nil
         }
 
         /**
@@ -195,7 +199,8 @@ extension SessionProxy {
                 tlsWrap: tlsWrap,
                 keepAliveInterval: keepAliveInterval,
                 renegotiatesAfter: renegotiatesAfter,
-                usesPIAPatches: usesPIAPatches
+                usesPIAPatches: usesPIAPatches,
+                dnsServers: dnsServers
             )
         }
     }
@@ -233,6 +238,9 @@ extension SessionProxy {
         /// - Seealso: `SessionProxy.ConfigurationBuilder.usesPIAPatches`
         public let usesPIAPatches: Bool?
 
+        /// - Seealso: `SessionProxy.ConfigurationBuilder.dnsServers`
+        public let dnsServers: [String]?
+        
         /**
          Returns a `SessionProxy.ConfigurationBuilder` to use this configuration as a starting point for a new one.
          
@@ -249,6 +257,7 @@ extension SessionProxy {
             builder.keepAliveInterval = keepAliveInterval
             builder.renegotiatesAfter = renegotiatesAfter
             builder.usesPIAPatches = usesPIAPatches
+            builder.dnsServers = dnsServers
             return builder
         }
 
@@ -265,7 +274,8 @@ extension SessionProxy {
                 (lhs.compressionFraming == rhs.compressionFraming) &&
                 (lhs.keepAliveInterval == rhs.keepAliveInterval) &&
                 (lhs.renegotiatesAfter == rhs.renegotiatesAfter) &&
-                (lhs.usesPIAPatches == rhs.usesPIAPatches)
+                (lhs.usesPIAPatches == rhs.usesPIAPatches) &&
+                (lhs.dnsServers == rhs.dnsServers)
         }
     }
 }

--- a/TunnelKitTests/ConfigurationParserTests.swift
+++ b/TunnelKitTests/ConfigurationParserTests.swift
@@ -27,6 +27,8 @@ import XCTest
 import TunnelKit
 
 class ConfigurationParserTests: XCTestCase {
+    let base: [String] = ["<ca>", "</ca>", "remote 1.2.3.4"]
+    
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -55,14 +57,20 @@ class ConfigurationParserTests: XCTestCase {
     }
     
     func testCompression() throws {
-        let base: [String] = ["<ca>", "</ca>", "remote 1.2.3.4"]
-        
         XCTAssertNotNil(try ConfigurationParser.parsed(fromLines: base + ["comp-lzo"]).warning)
         XCTAssertNoThrow(try ConfigurationParser.parsed(fromLines: base + ["comp-lzo no"]))
         XCTAssertThrowsError(try ConfigurationParser.parsed(fromLines: base + ["comp-lzo yes"]))
 
         XCTAssertNoThrow(try ConfigurationParser.parsed(fromLines: base + ["compress"]))
         XCTAssertThrowsError(try ConfigurationParser.parsed(fromLines: base + ["compress lzo"]))
+    }
+    
+    func testDHCPOption() throws {
+        let lines = base + ["dhcp-option DNS 8.8.8.8", "dhcp-option DNS6 ffff::1"]
+        XCTAssertNoThrow(try ConfigurationParser.parsed(fromLines: lines))
+
+        let parsed = try! ConfigurationParser.parsed(fromLines: lines)
+        XCTAssertEqual(parsed.configuration.dnsServers, ["8.8.8.8", "ffff::1"])
     }
     
     private func url(withName name: String) -> URL {


### PR DESCRIPTION
Give user the option to override DNS servers (e.g. via `dhcp-option`) regardless of server's `PUSH_REPLY`.