### PR TITLE
DNS inconsistency issues

### DIFF
--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -564,6 +564,7 @@ extension TunnelKitProvider: SessionProxyDelegate {
         if dnsServers?.isEmpty ?? true {
             dnsServers = reply.options.dnsServers
         }
+        // FIXME: default to DNS servers from current network instead
         let dnsSettings = NEDNSSettings(servers: dnsServers ?? [])
         if let searchDomain = cfg.sessionConfiguration.searchDomain ?? reply.options.searchDomain {
             dnsSettings.domainName = searchDomain

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -564,10 +564,9 @@ extension TunnelKitProvider: SessionProxyDelegate {
         if dnsServers?.isEmpty ?? true {
             dnsServers = reply.options.dnsServers
         }
-        let searchDomain = cfg.sessionConfiguration.searchDomain ?? reply.options.searchDomain
         let dnsSettings = NEDNSSettings(servers: dnsServers ?? [])
-        dnsSettings.domainName = searchDomain
-        if let searchDomain = searchDomain {
+        if let searchDomain = cfg.sessionConfiguration.searchDomain ?? reply.options.searchDomain {
+            dnsSettings.domainName = searchDomain
             dnsSettings.searchDomains = [searchDomain]
         }
         

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -560,7 +560,10 @@ extension TunnelKitProvider: SessionProxyDelegate {
             ipv6Settings?.excludedRoutes = []
         }
         
-        let dnsServers = cfg.sessionConfiguration.dnsServers ?? reply.options.dnsServers
+        var dnsServers = cfg.sessionConfiguration.dnsServers
+        if dnsServers?.isEmpty ?? true {
+            dnsServers = reply.options.dnsServers
+        }
         let searchDomain = cfg.sessionConfiguration.searchDomain ?? reply.options.searchDomain
         let dnsSettings = NEDNSSettings(servers: dnsServers ?? [])
         dnsSettings.domainName = searchDomain

--- a/TunnelKit/Sources/Core/ConfigurationParser.swift
+++ b/TunnelKit/Sources/Core/ConfigurationParser.swift
@@ -199,7 +199,7 @@ public class ConfigurationParser {
         var optGateway4Arguments: [String]?
         var optRoutes4: [(String, String, String?)] = [] // address, netmask, gateway
         var optRoutes6: [(String, UInt8, String?)] = [] // destination, prefix, gateway
-        var optDNSServers: [String] = []
+        var optDNSServers: [String]?
         var optSearchDomain: String?
         var optHTTPProxy: Proxy?
         var optHTTPSProxy: Proxy?
@@ -482,7 +482,10 @@ public class ConfigurationParser {
                 guard $0.count == 2 else {
                     return
                 }
-                optDNSServers.append($0[1])
+                if optDNSServers == nil {
+                    optDNSServers = []
+                }
+                optDNSServers?.append($0[1])
             }
             Regex.domain.enumerateArguments(in: line) {
                 guard $0.count == 2 else {


### PR DESCRIPTION
Regression in Passepartout 1.4.0 from 1.3.0.

The recent refactoring of `ConfigurationParser` brought a couple issues:

1. `dnsServers` defaults to [] rather than nil, but this was actually like before.

2. However, the new code in `TunnelKitProvider.bringNetworkUp(...)` was affected by 1 because:

```
let dnsServers = cfg.sessionConfiguration.dnsServers ?? reply.options.dnsServers
```

didn't check for `dnsServers.isEmpty`. So basically, if `cfg.sessionConfiguration.dnsServers` was non-nil but empty, it overrode the server-pushed DNS `reply.options.dnsServers`.

Simple fix: default `dnsServers` to nil when none is set.

Thorough, backwards-compatible fix:

```
var dnsServers = cfg.sessionConfiguration.dnsServers
if dnsServers?.isEmpty ?? true {
    dnsServers = reply.options.dnsServers
}
```