### PR TITLE
Split tunnelling

### DIFF
--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -477,7 +477,11 @@ extension TunnelKitProvider: SessionProxyDelegate {
         log.info("\tIPv4: \(reply.options.ipv4?.description ?? "not configured")")
         log.info("\tIPv6: \(reply.options.ipv6?.description ?? "not configured")")
         // FIXME: refine logging of other routing policies
-        log.info("\tDefault gateway: \(reply.options.routingPolicies?.maskedDescription ?? "not configured")")
+        if let routingPolicies = reply.options.routingPolicies {
+            log.info("\tDefault gateway: \(routingPolicies.map { $0.rawValue })")
+        } else {
+            log.info("\tDefault gateway: not configured")
+        }
         if let dnsServers = reply.options.dnsServers, !dnsServers.isEmpty {
             log.info("\tDNS: \(dnsServers.map { $0.maskedDescription })")
         } else {

--- a/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
+++ b/TunnelKit/Sources/AppExtension/TunnelKitProvider.swift
@@ -538,9 +538,13 @@ extension TunnelKitProvider: SessionProxyDelegate {
 
             // route all traffic to VPN?
             if routingPolicies?.contains(.IPv4) ?? false {
-                let defaultRoute = NEIPv4Route.default()
-                defaultRoute.gatewayAddress = ipv4.defaultGateway
-                routes.append(defaultRoute)
+//                let defaultRoute = NEIPv4Route.default()
+//                defaultRoute.gatewayAddress = ipv4.defaultGateway
+//                routes.append(defaultRoute)
+                for network in ["0.0.0.0", "128.0.0.0"] {
+                    let route = NEIPv4Route(destinationAddress: network, subnetMask: "128.0.0.0")
+                    routes.append(route)
+                }
             }
             
             for r in ipv4.routes {
@@ -560,9 +564,13 @@ extension TunnelKitProvider: SessionProxyDelegate {
 
             // route all traffic to VPN?
             if routingPolicies?.contains(.IPv6) ?? false {
-                let defaultRoute = NEIPv6Route.default()
-                defaultRoute.gatewayAddress = ipv6.defaultGateway
-                routes.append(defaultRoute)
+//                let defaultRoute = NEIPv6Route.default()
+//                defaultRoute.gatewayAddress = ipv6.defaultGateway
+//                routes.append(defaultRoute)
+                for network in ["2000::", "3000::"] {
+                    let route = NEIPv6Route(destinationAddress: network, networkPrefixLength: 4)
+                    routes.append(route)
+                }
             }
 
             for r in ipv6.routes {


### PR DESCRIPTION
Use OpenVPN trick to retain default gateway, i.e. split the default address space into two complementary networks:

- IPv4: 0.0.0.0/1 and 128.0.0.0/1
- IPv6: 2000::/4 and 3000::/4

This way, the original gateway is retained.

Handle `def1`, `ipv6` and `!ipv4` args to `redirect-gateway` properly.