### PR TITLE
Opt out of platform info in peer info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- OpenVPN: Opt out of platform info in peer info. [#409](https://github.com/passepartoutvpn/tunnelkit/pull/409)
+
 ## 6.3.2 (2024-01-05)
 
 ### Fixed

--- a/Sources/TunnelKitOpenVPNProtocol/CoreConfiguration+OpenVPN.swift
+++ b/Sources/TunnelKitOpenVPNProtocol/CoreConfiguration+OpenVPN.swift
@@ -64,18 +64,10 @@ extension CoreConfiguration {
 
         // MARK: Authentication
 
-        static func peerInfo(extra: [String: String]? = nil) -> String {
-            let platform: String
-            let platformVersion = ProcessInfo.processInfo.operatingSystemVersion
-            #if os(iOS)
-            platform = "ios"
-            #else
-            platform = "mac"
-            #endif
+        static func peerInfo(withPlatform: Bool = true, extra: [String: String]? = nil) -> String {
             let uiVersion = versionIdentifier ?? "\(identifier) \(version)"
             var info = [
                 "IV_VER=2.4",
-                "IV_PLAT=\(platform)",
                 "IV_UI_VER=\(uiVersion)",
                 "IV_PROTO=2",
                 "IV_NCP=2",
@@ -89,10 +81,24 @@ extension CoreConfiguration {
 //            if pushPeerInfo {
             if true {
                 info.append("IV_SSL=\(CryptoBox.version())")
+            }
+            if withPlatform {
+                let platform: String
+                let platformVersion = ProcessInfo.processInfo.operatingSystemVersion
+#if os(iOS)
+                platform = "ios"
+#elseif os(tvOS)
+                platform = "tvos"
+#else
+                platform = "mac"
+#endif
+                info.append("IV_PLAT=\(platform)")
                 info.append("IV_PLAT_VER=\(platformVersion.majorVersion).\(platformVersion.minorVersion)")
             }
-            if let extra = extra {
-                info.append(contentsOf: extra.map { "\($0)=\($1)" })
+            if let extra {
+                info.append(contentsOf: extra.map {
+                    "\($0)=\($1)"
+                })
             }
             info.append("")
             return info.joined(separator: "\n")


### PR DESCRIPTION
Enabled by default for backward compatibility.

Fixes #343